### PR TITLE
Edit completed swiss group

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/gui/gui.pro.user
+/build*

--- a/gui/swisstable.cpp
+++ b/gui/swisstable.cpp
@@ -67,18 +67,22 @@ void SwissTable::setupCells()
 void SwissTable::editMatchResults( int row, int col )
 {
   int mIndex = row - 1;
- 
-  if ( _group->readOnly() ) {
-    QMessageBox::information( this, _group->name(), 
-                              "Group cannot be edited!" );
-    qDebug() << __FUNCTION__ << "group cannot be edited!";
-    return;
-  }
 
   Match m = _group->matchList().at( mIndex );
   MatchResDialog dialog( m, this );
 
   if ( dialog.exec() == QDialog::Accepted ) {
+      if (_group->readOnly()) {  // For read only groups, only allow edits if the match winner outcome will not change
+          Match editedMatch = dialog.match();
+
+          if (!(m.winner() == editedMatch.winner())) {
+              QMessageBox::information( this, _group->name(),
+                                        "You cannot change the match winner on a finished group." );
+              qDebug() << __FUNCTION__ << "group cannot be edited (winner would change)!";
+              return;
+          }
+      }
+
     _group->setMatchResults( dialog.match() ); 
 
     updateMatchCell( row, col );

--- a/gui/tourndata.cpp
+++ b/gui/tourndata.cpp
@@ -83,20 +83,22 @@ MatchList TournData::matchList( int stage ) const
   Q_ASSERT( g != NULL );
   Q_ASSERT( _tournament != NULL );
 
-  if ( g->stage() == 0 && ( algo()->props().type != TournProps::PlayOff ) ) {
-    // 0th stage is for qualification (RoundRobin or another one).
-    // it should be fully completed before next stage.
-    if ( _algo->stageCompleted( _groups[0] ) ) {
-      _groups[1] = _algo->buildGroups( 1, _groups[0] );
-      foreach( Group *gr, _groups[ 1 ] ) {
-        gr->setTournData( this );
+  if (!g->readOnly()) {
+      if ( g->stage() == 0 && ( algo()->props().type != TournProps::PlayOff )) {
+        // 0th stage is for qualification (RoundRobin or another one).
+        // it should be fully completed before next stage.
+        if ( _algo->stageCompleted( _groups[0] ) ) {
+          _groups[1] = _algo->buildGroups( 1, _groups[0] );
+          foreach( Group *gr, _groups[ 1 ] ) {
+            gr->setTournData( this );
+          }
+         }
+      } else {
+        if ( g->completed() && ( !_algo->isStageLast( g->stage() ) ) ) {
+          _groups[ g->stage() + 1 ] << dynamic_cast< SwissGroup* >( g )->split();
+          // split() function should set tourn data
+        }
       }
-    }
-  } else {
-    if ( g->completed() && ( !_algo->isStageLast( g->stage() ) ) ) {
-      _groups[ g->stage() + 1 ] << dynamic_cast< SwissGroup* >( g )->split();
-      // split() function should set tourn data 
-    }
   }
 
   if ( _tournament ) {


### PR DESCRIPTION
Allow completed swiss groups to be edited as long as they don't change the match outcome (which would break the pre-made groups). Sometimes it's necessary to correct input scores on a match in a read only group, and it was disallowed because propagating changes would affect newly built groups (clean them).